### PR TITLE
Переработка механизма работы стратегий

### DIFF
--- a/strategy/default.txt
+++ b/strategy/default.txt
@@ -1,0 +1,11 @@
+--wf-l3=ipv4,ipv6 --wf-tcp=80,443,6695-6705 --wf-udp=443,50000-50100,1024-65535
+--filter-tcp=443 --ipset=/opt/zapret/lists/russia-youtube-rtmps.txt --dpi-desync=syndata --dpi-desync-fake-syndata=/opt/zapret/bin/tls_clienthello_4.bin --dpi-desync-autottl --new
+--filter-tcp=443 --hostlist=/opt/zapret/lists/youtube_v2.txt --dpi-desync=multisplit --dpi-desync-split-seqovl=1 --dpi-desync-split-pos=midsld+1 --new
+--filter-tcp=443 --hostlist=/opt/zapret/lists/youtubeGV.txt --dpi-desync=multisplit --dpi-desync-split-seqovl=1 --dpi-desync-split-pos=midsld-1 --new
+--filter-udp=443 --hostlist=/opt/zapret/lists/youtubeQ.txt --dpi-desync=fake,udplen --dpi-desync-udplen-increment=4 --dpi-desync-fake-quic=/opt/zapret/bin/quic_3.bin --dpi-desync-cutoff=n3 --dpi-desync-repeats=2 --new
+--filter-tcp=443 --ipset=/opt/zapret/lists/ipset-discord.txt --dpi-desync=syndata --dpi-desync-fake-syndata=/opt/zapret/bin/tls_clienthello_3.bin --dpi-desync-autottl --new
+--filter-udp=443 --hostlist=/opt/zapret/lists/discord.txt --dpi-desync=fake,udplen --dpi-desync-udplen-increment=5 --dpi-desync-udplen-pattern=0xDEADBEEF --dpi-desync-fake-quic=/opt/zapret/bin/quic_2.bin --dpi-desync-repeats=7 --dpi-desync-cutoff=n2 --new
+--filter-udp=50000-50090 --dpi-desync=fake --dpi-desync-any-protocol --dpi-desync-cutoff=n3 --new
+--filter-tcp=443 --hostlist-domains=googlevideo.com --dpi-desync=multidisorder --dpi-desync-split-seqovl=1 --dpi-desync-split-pos=1,host+2,sld+2,sld+5,sniext+1,sniext+2,endhost-2 --new
+--filter-tcp=6695-6705 --dpi-desync=fake,split2 --dpi-desync-repeats=8 --dpi-desync-fooling=md5sig --dpi-desync-autottl=2 --dpi-desync-fake-tls=/opt/zapret/bin/tls_clienthello_www_google_com.bin --new
+--filter-tcp=443 --hostlist-exclude=/opt/zapret/lists/netrogat.txt --dpi-desync=fakedsplit --dpi-desync-split-pos=1 --dpi-desync-fooling=badseq --dpi-desync-repeats=10 --dpi-desync-autottl --new

--- a/strategy/mts_mgts.txt
+++ b/strategy/mts_mgts.txt
@@ -1,0 +1,7 @@
+--wf-tcp=80,443 --wf-udp=443,50000-59000
+--filter-udp=443 --hostlist=/opt/zapret/autohosts.txt --hostlist-exclude=/opt/zapret/ignore.txt --dpi-desync=fake --dpi-desync-repeats=2 --dpi-desync-cutoff=n2 --dpi-desync-fake-quic=/opt/zapret/system/quic_initial_www_google_com.bin --new
+--filter-tcp=443 --hostlist=/opt/zapret/autohosts.txt --hostlist-exclude=/opt/zapret/ignore.txt --dpi-desync=fake,split2 --dpi-desync-split-seqovl=2 --dpi-desync-split-pos=3 --dpi-desync-fake-tls=/opt/zapret/system/tls_clienthello_www_google_com.bin --dpi-desync-ttl=3 --new
+--filter-udp=443 --hostlist=/opt/zapret/autohosts.txt --hostlist-exclude=/opt/zapret/ignore.txt --dpi-desync=fake --dpi-desync-udplen-increment=10 --dpi-desync-repeats=7 --dpi-desync-udplen-pattern=0xDEADBEEF --dpi-desync-fake-quic=/opt/zapret/system/quic_initial_www_google_com.bin --dpi-desync-cutoff=n2 --new
+--filter-udp=50000-59000 --dpi-desync=fake,split2 --dpi-desync-any-protocol --dpi-desync-cutoff=d2 --dpi-desync-fake-quic=/opt/zapret/system/quic_initial_www_google_com.bin --new
+--filter-tcp=443 --hostlist=/opt/zapret/autohosts.txt --hostlist-exclude=/opt/zapret/ignore.txt --dpi-desync=split --dpi-desync-split-pos=1 --dpi-desync-fooling=badseq --dpi-desync-repeats=10 --dpi-desync-ttl=4 --new
+--filter-tcp=443 --hostlist=/opt/zapret/autohosts.txt --hostlist-exclude=/opt/zapret/ignore.txt --dpi-desync=fake,split2 --dpi-desync-split-seqovl=1 --dpi-desync-split-tls=sniext --dpi-desync-fake-tls=/opt/zapret/system/tls_clienthello_www_google_com.bin --dpi-desync-ttl=2 --new

--- a/strategy/rostelecom_tele2.txt
+++ b/strategy/rostelecom_tele2.txt
@@ -1,0 +1,6 @@
+--wf-tcp=80,443 --wf-udp=443,50000-59000
+--filter-udp=443 --hostlist=/opt/zapret/autohosts.txt --hostlist-exclude=/opt/zapret/ignore.txt --dpi-desync=fake --dpi-desync-repeats=2 --dpi-desync-cutoff=n2 --dpi-desync-fake-quic=/opt/zapret/system/quic_initial_www_google_com.bin --new
+--filter-tcp=443 --hostlist=/opt/zapret/autohosts.txt --hostlist-exclude=/opt/zapret/ignore.txt --dpi-desync=split --dpi-desync-split-pos=1 --dpi-desync-fooling=badseq --dpi-desync-repeats=10 --dpi-desync-cutoff=d2 --dpi-desync-ttl=4 --new
+--filter-tcp=443 --hostlist=/opt/zapret/autohosts.txt --hostlist-exclude=/opt/zapret/ignore.txt --dpi-desync=fake,split2 --dpi-desync-split-seqovl=2 --dpi-desync-split-pos=3 --dpi-desync-fake-tls=/opt/zapret/system/tls_clienthello_www_google_com.bin --dpi-desync-ttl=3 --new
+--filter-udp=50000-59000 --dpi-desync=fake --dpi-desync-any-protocol --dpi-desync-cutoff=d3 --dpi-desync-repeats=6 --new
+--filter-tcp=443 --hostlist=/opt/zapret/autohosts.txt --hostlist-exclude=/opt/zapret/ignore.txt --dpi-desync=fake,split2 --dpi-desync-split-seqovl=1 --dpi-desync-split-tls=sniext --dpi-desync-fake-tls=/opt/zapret/system/tls_clienthello_www_google_com.bin --dpi-desync-ttl=2 --new


### PR DESCRIPTION
### Что изменено
- Стратегии больше не записываются в файл `config.txt` в `/opt/zapret/`
- Экран раздела `Стратегия`

### Что добавлено
- Список стратегий динамический, выбор происходит в `Combobox` в разделе `Стратегия`
- Стратегии теперь хранятся в папке `strategy`
- Стратегии не переносятся в `/opt/zapret`, вместо этого создаётся `symlink` на файл с стратегией

<img width="1082" height="509" alt="Screenshot_20251007_201512" src="https://github.com/user-attachments/assets/cc97ec56-a0bb-493a-b93a-fae8752da4cd" />


Целью данной модификации было прийти к динамическому добавлению стратегий, в связи с последними изменениями в интернете.
Протестировано лично мной на палубе, но возможны баги.
@mashakulina 
